### PR TITLE
Use -dirty suffix instead of .dirty

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -51,7 +51,7 @@
       <BraintrustSdkVersion Condition="'$(CurrentTagExitCode)' != '0' and '$(MostRecentTagExitCode)' == '0'">$(CleanMostRecentTag)-$(GitSha)</BraintrustSdkVersion>
       <!-- If no tags at all, use 0.0.0-dev-sha format for NuGet compatibility -->
       <BraintrustSdkVersion Condition="'$(CurrentTagExitCode)' != '0' and '$(MostRecentTagExitCode)' != '0'">0.0.0-dev-$(GitSha)</BraintrustSdkVersion>
-      <!-- Append -dirty if workspace is not clean (use dot for prerelease component) -->
+      <!-- Append -dirty if workspace is not clean -->
       <BraintrustSdkVersion Condition="'$(IsDirty)' == 'true'">$(BraintrustSdkVersion)-dirty</BraintrustSdkVersion>
 
       <!-- Fallback to "0.0.0-unknown" if git is not available -->


### PR DESCRIPTION
`0.0.0.dirty` is apparently not a valid version, it caused an error:

```
1>C:\Program Files\dotnet\sdk\8.0.417\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.GenerateAssemblyInfo.targets(226,5): error NETSDK1018: Invalid NuGet version string: '0.0.2.dirty'.
```