### PR TITLE
Support for async tasks and scorers

### DIFF
--- a/src/Braintrust.Sdk/Eval/FunctionScorer.cs
+++ b/src/Braintrust.Sdk/Eval/FunctionScorer.cs
@@ -1,7 +1,7 @@
 namespace Braintrust.Sdk.Eval;
 
 /// <summary>
-/// Implementation of a scorer from a function.
+/// Implementation of a scorer from a synchronous function.
 /// </summary>
 public class FunctionScorer<TInput, TOutput> : IScorer<TInput, TOutput>
     where TInput : notnull
@@ -17,8 +17,33 @@ public class FunctionScorer<TInput, TOutput> : IScorer<TInput, TOutput>
 
     public string Name { get; }
 
-    public IReadOnlyList<Score> Score(TaskResult<TInput, TOutput> taskResult)
+    public Task<IReadOnlyList<Score>> Score(TaskResult<TInput, TOutput> taskResult)
     {
-        return [new Score(Name, _scorerFn(taskResult.DatasetCase.Expected, taskResult.Result))];
+        IReadOnlyList<Score> scores = [new Score(Name, _scorerFn(taskResult.DatasetCase.Expected, taskResult.Result))];
+        return Task.FromResult(scores);
+    }
+}
+
+/// <summary>
+/// Implementation of a scorer from an asynchronous function.
+/// </summary>
+public class AsyncFunctionScorer<TInput, TOutput> : IScorer<TInput, TOutput>
+    where TInput : notnull
+    where TOutput : notnull
+{
+    private readonly Func<TOutput, TOutput, Task<double>> _scorerFn;
+
+    public AsyncFunctionScorer(string name, Func<TOutput, TOutput, Task<double>> scorerFn)
+    {
+        Name = name;
+        _scorerFn = scorerFn;
+    }
+
+    public string Name { get; }
+
+    public async Task<IReadOnlyList<Score>> Score(TaskResult<TInput, TOutput> taskResult)
+    {
+        var score = await _scorerFn(taskResult.DatasetCase.Expected, taskResult.Result).ConfigureAwait(false);
+        return [new Score(Name, score)];
     }
 }

--- a/src/Braintrust.Sdk/Eval/IScorer.cs
+++ b/src/Braintrust.Sdk/Eval/IScorer.cs
@@ -17,5 +17,5 @@ public interface IScorer<TInput, TOutput>
     /// <summary>
     /// Score the task result and return one or more scores.
     /// </summary>
-    IReadOnlyList<Score> Score(TaskResult<TInput, TOutput> taskResult);
+    Task<IReadOnlyList<Score>> Score(TaskResult<TInput, TOutput> taskResult);
 }

--- a/src/Braintrust.Sdk/Eval/ITask.cs
+++ b/src/Braintrust.Sdk/Eval/ITask.cs
@@ -12,5 +12,5 @@ public interface ITask<TInput, TOutput>
     /// <summary>
     /// Apply the task to a dataset case and return the result.
     /// </summary>
-    TaskResult<TInput, TOutput> Apply(DatasetCase<TInput, TOutput> datasetCase);
+    Task<TaskResult<TInput, TOutput>> Apply(DatasetCase<TInput, TOutput> datasetCase);
 }

--- a/tests/Braintrust.Sdk.Tests/Eval/EvalTest.cs
+++ b/tests/Braintrust.Sdk.Tests/Eval/EvalTest.cs
@@ -259,7 +259,7 @@ public class EvalTest : IDisposable
     }
 
     [Fact]
-    public void ScorerCreatesValidScore()
+    public async Task ScorerCreatesValidScore()
     {
         var scorer = new FunctionScorer<string, string>("test_scorer", (expected, actual) => expected == actual ? 1.0 : 0.0);
         var taskResult = new TaskResult<string, string>(
@@ -267,7 +267,7 @@ public class EvalTest : IDisposable
             DatasetCase.Of("input", "expected")
         );
 
-        var scores = scorer.Score(taskResult);
+        var scores = await scorer.Score(taskResult);
 
         Assert.Single(scores);
         Assert.Equal("test_scorer", scores[0].Name);


### PR DESCRIPTION
### What

Adds async/await support for both task functions and scorers, bringing the .NET SDK to parity with the [TypeScript](https://github.com/braintrustdata/braintrust-sdk/blob/main/js/src/framework.ts) and [Python](https://github.com/braintrustdata/braintrust-sdk/blob/main/py/src/braintrust/framework.py) SDKs.

### Motivation

The previous implementation only supported synchronous task functions and scorers, but we want to be able to execute async operatons. A good example is having LLM judge, which would require an async call to LLM proivder.

Both the TypeScript SDK ([`EvalTask`](https://github.com/braintrustdata/braintrust-sdk/blob/main/js/src/framework.ts#L104-L118) type) and Python SDK ([`EvalTask`](https://github.com/braintrustdata/braintrust-sdk/blob/main/py/src/braintrust/framework.py#L303-L306) type) support async task functions and scorers natively.

### Changes

**Task functions:**
- `ITask<TInput, TOutput>.Apply()` now returns `Task<TaskResult<...>>`
- `TaskFunction()` builder method accepts both `Func<TInput, TOutput>` (sync) and `Func<TInput, Task<TOutput>>` (async)

**Scorers:**
- `IScorer<TInput, TOutput>.Score()` now returns `Task<IReadOnlyList<Score>>`
- Added `AsyncFunctionScorer<TInput, TOutput>` for async scoring functions (e.g., LLM-as-judge)

### Usage

```csharp
var eval = await braintrust
    .EvalBuilder<string, string>()
    .Name("my-eval")
    .Cases(...)
    // Async task function - can call LLMs, APIs, etc.
    .TaskFunction(async (string input) =>
    {
        var response = await llmClient.CompleteAsync(input);
        return response.Text;
    })
    .Scorers(
        // Sync scorer (existing pattern)
        new FunctionScorer<string, string>("exact_match",
            (expected, actual) => expected == actual ? 1.0 : 0.0),
        // Async scorer (new) - can use LLM-as-judge
        new AsyncFunctionScorer<string, string>("llm_judge",
            async (expected, actual) => await llmClient.JudgeAsync(expected, actual))
    )
    .BuildAsync();