### PR TITLE
Support parallel execution with MaxConcurrency option

### DIFF
--- a/src/Braintrust.Sdk/Eval/FunctionScorer.cs
+++ b/src/Braintrust.Sdk/Eval/FunctionScorer.cs
@@ -1,7 +1,7 @@
 namespace Braintrust.Sdk.Eval;
 
 /// <summary>
-/// Implementation of a scorer from a function.
+/// Implementation of a scorer from a synchronous function.
 /// </summary>
 public class FunctionScorer<TInput, TOutput> : IScorer<TInput, TOutput>
     where TInput : notnull
@@ -17,8 +17,33 @@ public class FunctionScorer<TInput, TOutput> : IScorer<TInput, TOutput>
 
     public string Name { get; }
 
-    public IReadOnlyList<Score> Score(TaskResult<TInput, TOutput> taskResult)
+    public Task<IReadOnlyList<Score>> Score(TaskResult<TInput, TOutput> taskResult)
     {
-        return [new Score(Name, _scorerFn(taskResult.DatasetCase.Expected, taskResult.Result))];
+        IReadOnlyList<Score> scores = [new Score(Name, _scorerFn(taskResult.DatasetCase.Expected, taskResult.Result))];
+        return Task.FromResult(scores);
+    }
+}
+
+/// <summary>
+/// Implementation of a scorer from an asynchronous function.
+/// </summary>
+public class AsyncFunctionScorer<TInput, TOutput> : IScorer<TInput, TOutput>
+    where TInput : notnull
+    where TOutput : notnull
+{
+    private readonly Func<TOutput, TOutput, Task<double>> _scorerFn;
+
+    public AsyncFunctionScorer(string name, Func<TOutput, TOutput, Task<double>> scorerFn)
+    {
+        Name = name;
+        _scorerFn = scorerFn;
+    }
+
+    public string Name { get; }
+
+    public async Task<IReadOnlyList<Score>> Score(TaskResult<TInput, TOutput> taskResult)
+    {
+        var score = await _scorerFn(taskResult.DatasetCase.Expected, taskResult.Result).ConfigureAwait(false);
+        return [new Score(Name, score)];
     }
 }

--- a/src/Braintrust.Sdk/Eval/IScorer.cs
+++ b/src/Braintrust.Sdk/Eval/IScorer.cs
@@ -17,5 +17,5 @@ public interface IScorer<TInput, TOutput>
     /// <summary>
     /// Score the task result and return one or more scores.
     /// </summary>
-    IReadOnlyList<Score> Score(TaskResult<TInput, TOutput> taskResult);
+    Task<IReadOnlyList<Score>> Score(TaskResult<TInput, TOutput> taskResult);
 }

--- a/src/Braintrust.Sdk/Eval/ITask.cs
+++ b/src/Braintrust.Sdk/Eval/ITask.cs
@@ -12,5 +12,5 @@ public interface ITask<TInput, TOutput>
     /// <summary>
     /// Apply the task to a dataset case and return the result.
     /// </summary>
-    TaskResult<TInput, TOutput> Apply(DatasetCase<TInput, TOutput> datasetCase);
+    Task<TaskResult<TInput, TOutput>> Apply(DatasetCase<TInput, TOutput> datasetCase);
 }

--- a/tests/Braintrust.Sdk.Tests/Eval/EvalTest.cs
+++ b/tests/Braintrust.Sdk.Tests/Eval/EvalTest.cs
@@ -259,7 +259,7 @@ public class EvalTest : IDisposable
     }
 
     [Fact]
-    public void ScorerCreatesValidScore()
+    public async Task ScorerCreatesValidScore()
     {
         var scorer = new FunctionScorer<string, string>("test_scorer", (expected, actual) => expected == actual ? 1.0 : 0.0);
         var taskResult = new TaskResult<string, string>(
@@ -267,7 +267,7 @@ public class EvalTest : IDisposable
             DatasetCase.Of("input", "expected")
         );
 
-        var scores = scorer.Score(taskResult);
+        var scores = await scorer.Score(taskResult);
 
         Assert.Single(scores);
         Assert.Equal("test_scorer", scores[0].Name);


### PR DESCRIPTION
⚠️ Depends on #14 

### What

Adds parallel execution support for both cases and scorers, bringing the .NET SDK to parity with the [TypeScript](https://github.com/braintrustdata/braintrust-sdk/blob/main/js/src/framework.ts) and [Python](https://github.com/braintrustdata/braintrust-sdk/blob/main/py/src/braintrust/framework.py) SDKs.

### Motivation

The current implementation ran everything sequentially - each case waited for the previous one to complete, and
each scorer ran one after another. This is inefficient when evaluating many cases or when tasks/scorers involve I/O
operations like LLM API calls.

Both the TypeScript SDK ([`maxConcurrency`](https://github.com/braintrustdata/braintrust-sdk/blob/main/js/src/framework.ts#L289) option, [`Promise.all`](https://github.com/braintrustdata/braintrust-sdk/blob/main/js/src/framework.ts#L1121) for scorers) and Python SDK
([`max_concurrency`](https://github.com/braintrustdata/braintrust-sdk/blob/main/py/src/braintrust/framework.py#L385) option, [`asyncio.Semaphore`](https://github.com/braintrustdata/braintrust-sdk/blob/main/py/src/braintrust/framework.py#L1638-L1639) for concurrency control) run cases and scorers in parallel by default.

### Changes

**Case execution:**
- Cases now run in parallel by default using `Task.WhenAll()`
- Added `MaxConcurrency(int?)` builder method to optionally limit concurrent case evaluations

**Scorer execution:**
- Scorers within each case now run in parallel using `Task.WhenAll()`

### Usage

```csharp
// Default: unlimited parallelism (all cases run concurrently)
var eval = await Eval<string, string>.NewBuilder()
    .Name("my-eval")
    .Cases(case1, case2, case3, case4, case5)
    .TaskFunction(async input => await llmClient.CompleteAsync(input))
    .Scorers(scorer1, scorer2, scorer3)  // All scorers run in parallel per case
    .BuildAsync();

// With concurrency limit (e.g., to respect API rate limits)
var eval = await Eval<string, string>.NewBuilder()
    .Name("my-eval")
    .Cases(cases)
    .TaskFunction(async input => await llmClient.CompleteAsync(input))
    .MaxConcurrency(5)  // At most 5 cases evaluated concurrently
    .Scorers(scorer1, scorer2)
    .BuildAsync();
```

### Notes

| Feature | TypeScript | Python | .NET |
| --- | --- | --- | --- |
| Option name | `maxConcurrency?: number` | <code>max_concurrency: int &#124; None</code> | `MaxConcurrency(int?)` |
| Default behavior | Unlimited parallel | Unlimited parallel | Unlimited parallel |
| Parallel scorers | `Promise.all()` | `asyncio.create_task()` | `Task.WhenAll()` |
| Concurrency control | `async.queue()` | `asyncio.Semaphore` | `SemaphoreSlim` |