### PR TITLE
feat: Add braintrust.span_attributes type tag to LLM spans

### DIFF
--- a/src/Braintrust.Sdk.Anthropic/InstrumentedMessageService.cs
+++ b/src/Braintrust.Sdk.Anthropic/InstrumentedMessageService.cs
@@ -203,6 +203,7 @@ internal sealed class InstrumentedMessageService : IMessageService
         double? timeToFirstToken = null)
     {
         activity.SetTag("provider", "anthropic");
+        activity.SetTag("braintrust.span_attributes", "{\"type\":\"llm\"}");
         activity.SetTag("gen_ai.request.model", request.Model.Raw());
         activity.SetTag("gen_ai.response.model", response.Model.Raw());
 
@@ -259,6 +260,7 @@ internal sealed class InstrumentedMessageService : IMessageService
     {
         activity.SetTag("stream", true);
         activity.SetTag("provider", "anthropic");
+        activity.SetTag("braintrust.span_attributes", "{\"type\":\"llm\"}");
         activity.SetTag("gen_ai.request.model", request.Model.Raw());
 
         try

--- a/src/Braintrust.Sdk.OpenAI/InstrumentedChatClient.cs
+++ b/src/Braintrust.Sdk.OpenAI/InstrumentedChatClient.cs
@@ -141,6 +141,7 @@ internal sealed class InstrumentedChatClient : ChatClient
         IEnumerable<ChatMessage>? messages)
     {
         activity.SetTag("provider", "openai");
+        activity.SetTag("braintrust.span_attributes", "{\"type\":\"llm\"}");
 
         var requestRaw = activity.GetBaggageItem("braintrust.http.request");
         var responseRaw = activity.GetBaggageItem("braintrust.http.response");

--- a/tests/Braintrust.Sdk.Anthropic.Tests/BraintrustAnthropicTest.cs
+++ b/tests/Braintrust.Sdk.Anthropic.Tests/BraintrustAnthropicTest.cs
@@ -170,6 +170,11 @@ public class BraintrustAnthropicTest : IDisposable
 
         var ttft = Convert.ToDouble(timeToFirstToken);
         Assert.True(ttft >= 0, "time_to_first_token should be non-negative");
+
+        // Verify span attributes type is set to "llm"
+        var spanAttributes = span.GetTagItem("braintrust.span_attributes") as string;
+        Assert.NotNull(spanAttributes);
+        Assert.Contains("\"type\":\"llm\"", spanAttributes);
     }
 
     [Fact]

--- a/tests/Braintrust.Sdk.OpenAI.Tests/BraintrustOpenAITest.cs
+++ b/tests/Braintrust.Sdk.OpenAI.Tests/BraintrustOpenAITest.cs
@@ -182,6 +182,11 @@ public class BraintrustOpenAITest : IDisposable
         // Verify time_to_first_token is a non-negative number
         var ttft = Convert.ToDouble(timeToFirstToken);
         Assert.True(ttft >= 0, "time_to_first_token should be greater than or equal to 0");
+
+        // Verify span attributes type is set to "llm"
+        var spanAttributes = span.GetTagItem("braintrust.span_attributes") as string;
+        Assert.NotNull(spanAttributes);
+        Assert.Contains("\"type\":\"llm\"", spanAttributes);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes: https://github.com/braintrustdata/braintrust-sdk-dotnet/issues/52

Sets {"type":"llm"} span attribute on OpenAI and Anthropic instrumentation to enable LLM duration metrics and UI features like the "Try prompt" button in the Braintrust UI. Matches the pattern already implemented in the Agent Framework integration (SpanTagHelper.SetSpanType).

Changes:
- InstrumentedChatClient.TagActivity (OpenAI, line 144)
- InstrumentedMessageService.TagActivity (Anthropic, line 206)
- InstrumentedMessageService.TagStreamActivity (Anthropic, line 263)

Test assertions verify span attributes are set correctly on both OpenAI and Anthropic spans.