### PR TITLE
feat: capture request metadata

### DIFF
--- a/src/Braintrust.Sdk.Anthropic/InstrumentedMessageService.cs
+++ b/src/Braintrust.Sdk.Anthropic/InstrumentedMessageService.cs
@@ -240,6 +240,25 @@ internal sealed class InstrumentedMessageService : IMessageService
         {
             // Ignore errors
         }
+
+        // Build metadata from request params (mirrors Python SDK behavior)
+        try
+        {
+            var metadata = new Dictionary<string, object?> { ["provider"] = "anthropic" };
+            metadata["model"] = request.Model.Raw();
+            metadata["max_tokens"] = request.MaxTokens;
+            if (request.Temperature.HasValue) metadata["temperature"] = request.Temperature.Value;
+            if (request.TopP.HasValue) metadata["top_p"] = request.TopP.Value;
+            if (request.TopK.HasValue) metadata["top_k"] = request.TopK.Value;
+            if (request.StopSequences?.Count > 0) metadata["stop_sequences"] = request.StopSequences;
+            if (request.Tools?.Count > 0) metadata["tools"] = request.Tools;
+            if (request.ToolChoice is { } tc) metadata["tool_choice"] = tc;
+            activity.SetTag("braintrust.metadata", ToJson(metadata));
+        }
+        catch
+        {
+            // Ignore errors
+        }
     }
 
     private static string? ToJson<T>(T obj)
@@ -265,6 +284,25 @@ internal sealed class InstrumentedMessageService : IMessageService
         {
             var messagesJson = ToJson(request.Messages);
             activity.SetTag("braintrust.input_json", messagesJson);
+        }
+        catch
+        {
+            // Ignore errors
+        }
+
+        // Build metadata from request params
+        try
+        {
+            var metadata = new Dictionary<string, object?> { ["provider"] = "anthropic" };
+            metadata["model"] = request.Model.Raw();
+            metadata["max_tokens"] = request.MaxTokens;
+            if (request.Temperature.HasValue) metadata["temperature"] = request.Temperature.Value;
+            if (request.TopP.HasValue) metadata["top_p"] = request.TopP.Value;
+            if (request.TopK.HasValue) metadata["top_k"] = request.TopK.Value;
+            if (request.StopSequences?.Count > 0) metadata["stop_sequences"] = request.StopSequences;
+            if (request.Tools?.Count > 0) metadata["tools"] = request.Tools;
+            if (request.ToolChoice is { } tc) metadata["tool_choice"] = tc;
+            activity.SetTag("braintrust.metadata", ToJson(metadata));
         }
         catch
         {

--- a/src/Braintrust.Sdk.OpenAI/InstrumentedChatClient.cs
+++ b/src/Braintrust.Sdk.OpenAI/InstrumentedChatClient.cs
@@ -60,7 +60,7 @@ internal sealed class InstrumentedChatClient : ChatClient
             // Tag the activity with telemetry data
             if (activity != null && _captureMessageContent)
             {
-                TagActivity(activity, timeToFirstToken, result.Value, messages);
+                TagActivity(activity, timeToFirstToken, result.Value, messages, options);
             }
 
             return result;
@@ -103,7 +103,7 @@ internal sealed class InstrumentedChatClient : ChatClient
             // Tag the activity with telemetry data
             if (activity != null && _captureMessageContent)
             {
-                TagActivity(activity, timeToFirstToken, result.Value, messages);
+                TagActivity(activity, timeToFirstToken, result.Value, messages, options);
             }
 
             return result;
@@ -138,7 +138,8 @@ internal sealed class InstrumentedChatClient : ChatClient
         Activity activity,
         double? timeToFirstToken,
         ChatCompletion? completion,
-        IEnumerable<ChatMessage>? messages)
+        IEnumerable<ChatMessage>? messages,
+        ChatCompletionOptions? options = null)
     {
         activity.SetTag("provider", "openai");
 
@@ -153,7 +154,7 @@ internal sealed class InstrumentedChatClient : ChatClient
         else
         {
             // Fallback path: no transport injected, extract from typed API objects
-            TagActivityFromApiObjects(activity, completion, messages, timeToFirstToken);
+            TagActivityFromApiObjects(activity, completion, messages, timeToFirstToken, options);
         }
     }
 
@@ -168,6 +169,19 @@ internal sealed class InstrumentedChatClient : ChatClient
             var requestJson = JsonNode.Parse(requestRaw);
             activity.SetTag("gen_ai.request.model", requestJson?["model"]?.ToString());
             activity.SetTag("braintrust.input_json", requestJson?["messages"]?.ToString());
+
+            // Build metadata from all request fields except messages (mirrors Python SDK behavior)
+            if (requestJson is JsonObject requestObj)
+            {
+                var meta = new Dictionary<string, JsonNode?> { ["provider"] = JsonValue.Create("openai") };
+                foreach (var (key, value) in requestObj)
+                {
+                    if (key != "messages")
+                        meta[key] = value?.DeepClone();
+                }
+                try { activity.SetTag("braintrust.metadata", JsonSerializer.Serialize(meta)); }
+                catch { }
+            }
         }
 
         if (responseRaw != null)
@@ -206,7 +220,8 @@ internal sealed class InstrumentedChatClient : ChatClient
         Activity activity,
         ChatCompletion? completion,
         IEnumerable<ChatMessage>? messages,
-        double? timeToFirstToken)
+        double? timeToFirstToken,
+        ChatCompletionOptions? options = null)
     {
         // Input: serialize the messages parameter
         if (messages != null)
@@ -249,6 +264,32 @@ internal sealed class InstrumentedChatClient : ChatClient
             }
 
             SetTimeToFirstToken(activity, timeToFirstToken);
+        }
+
+        // Build metadata from request options
+        try
+        {
+            var metadata = new Dictionary<string, object?> { ["provider"] = "openai" };
+            if (completion?.Model != null)
+                metadata["model"] = completion.Model;
+            if (options != null)
+            {
+                if (options.Temperature.HasValue) metadata["temperature"] = options.Temperature.Value;
+                if (options.MaxOutputTokenCount.HasValue) metadata["max_tokens"] = options.MaxOutputTokenCount.Value;
+                if (options.TopP.HasValue) metadata["top_p"] = options.TopP.Value;
+                if (options.FrequencyPenalty.HasValue) metadata["frequency_penalty"] = options.FrequencyPenalty.Value;
+                if (options.PresencePenalty.HasValue) metadata["presence_penalty"] = options.PresencePenalty.Value;
+                if (options.StopSequences?.Count > 0) metadata["stop"] = options.StopSequences;
+                if (!string.IsNullOrEmpty(options.EndUserId)) metadata["user"] = options.EndUserId;
+                if (options.Tools?.Count > 0) metadata["tools"] = options.Tools;
+                if (options.ToolChoice != null) metadata["tool_choice"] = options.ToolChoice;
+                if (options.ResponseFormat != null) metadata["response_format"] = options.ResponseFormat;
+            }
+            activity.SetTag("braintrust.metadata", JsonSerializer.Serialize(metadata, JsonOptions));
+        }
+        catch
+        {
+            // Ignore serialization errors
         }
     }
 

--- a/tests/Braintrust.Sdk.Anthropic.Tests/BraintrustAnthropicTest.cs
+++ b/tests/Braintrust.Sdk.Anthropic.Tests/BraintrustAnthropicTest.cs
@@ -176,7 +176,7 @@ public class BraintrustAnthropicTest : IDisposable
         Assert.NotNull(metadataJson);
         Assert.Contains("\"provider\":\"anthropic\"", metadataJson);
         Assert.Contains("\"max_tokens\":1024", metadataJson);
-        
+
         // Verify span attributes type is set to "llm"
         var spanAttributes = span.GetTagItem("braintrust.span_attributes") as string;
         Assert.NotNull(spanAttributes);

--- a/tests/Braintrust.Sdk.Anthropic.Tests/BraintrustAnthropicTest.cs
+++ b/tests/Braintrust.Sdk.Anthropic.Tests/BraintrustAnthropicTest.cs
@@ -170,6 +170,12 @@ public class BraintrustAnthropicTest : IDisposable
 
         var ttft = Convert.ToDouble(timeToFirstToken);
         Assert.True(ttft >= 0, "time_to_first_token should be non-negative");
+
+        // Verify metadata was captured with provider and max_tokens
+        var metadataJson = span.GetTagItem("braintrust.metadata") as string;
+        Assert.NotNull(metadataJson);
+        Assert.Contains("\"provider\":\"anthropic\"", metadataJson);
+        Assert.Contains("\"max_tokens\":1024", metadataJson);
     }
 
     [Fact]

--- a/tests/Braintrust.Sdk.OpenAI.Tests/BraintrustOpenAITest.cs
+++ b/tests/Braintrust.Sdk.OpenAI.Tests/BraintrustOpenAITest.cs
@@ -182,6 +182,11 @@ public class BraintrustOpenAITest : IDisposable
         // Verify time_to_first_token is a non-negative number
         var ttft = Convert.ToDouble(timeToFirstToken);
         Assert.True(ttft >= 0, "time_to_first_token should be greater than or equal to 0");
+
+        // Verify metadata was captured with provider
+        var metadataJson = span.GetTagItem("braintrust.metadata") as string;
+        Assert.NotNull(metadataJson);
+        Assert.Contains("\"provider\":\"openai\"", metadataJson);
     }
 
     [Fact]
@@ -276,6 +281,11 @@ public class BraintrustOpenAITest : IDisposable
         // Verify time_to_first_token
         var ttft = Convert.ToDouble(span.GetTagItem("braintrust.metrics.time_to_first_token"));
         Assert.True(ttft >= 0);
+
+        // Verify metadata was captured with provider
+        var metadataJson = span.GetTagItem("braintrust.metadata") as string;
+        Assert.NotNull(metadataJson);
+        Assert.Contains("\"provider\":\"openai\"", metadataJson);
     }
 
     [Fact]

--- a/tests/Braintrust.Sdk.OpenAI.Tests/BraintrustOpenAITest.cs
+++ b/tests/Braintrust.Sdk.OpenAI.Tests/BraintrustOpenAITest.cs
@@ -187,7 +187,7 @@ public class BraintrustOpenAITest : IDisposable
         var metadataJson = span.GetTagItem("braintrust.metadata") as string;
         Assert.NotNull(metadataJson);
         Assert.Contains("\"provider\":\"openai\"", metadataJson);
-        
+
         // Verify span attributes type is set to "llm"
         var spanAttributes = span.GetTagItem("braintrust.span_attributes") as string;
         Assert.NotNull(spanAttributes);


### PR DESCRIPTION
fixes: https://github.com/braintrustdata/braintrust-sdk-dotnet/issues/55

## Summary

  OpenAI and Anthropic instrumentation now captures a braintrust.metadata tag on LLM spans containing all request parameters except messages — including model, temperature, max_tokens, tools, tool_choice, top_p, and
   more. This mirrors the Python SDK behavior where non-message params are separated into metadata for trace observability.

##  Changes

  - OpenAI (baggage path): Extracts all non-messages fields from the raw request JSON into braintrust.metadata (captures the full wire request including tools, temperature, max_tokens, response_format, etc.)
  - OpenAI (fallback path): Manually extracts temperature, max_tokens, top_p, frequency_penalty, presence_penalty, stop, end_user_id, tools, tool_choice, and response_format from ChatCompletionOptions
  - Anthropic: Captures model, max_tokens, temperature, top_p, top_k, stop_sequences, tools, and tool_choice from MessageCreateParams in both streaming and non-streaming paths
  - Tests: Added braintrust.metadata assertions to ChatCompletion_CapturesRequestAndResponse (both transport and fallback paths) and MessageCreation_CapturesRequestAndResponse

##  Format
```
  {
    "provider": "anthropic",
    "model": "claude-sonnet-4-20250514",
    "max_tokens": 512,
    "temperature": 0.7
  }
```