### PR TITLE
Add span origin provenance

### DIFF
--- a/src/Braintrust.Sdk/Config/BraintrustConfig.cs
+++ b/src/Braintrust.Sdk/Config/BraintrustConfig.cs
@@ -159,19 +159,15 @@ public sealed class BraintrustConfig : BaseConfig
 
     private SpanOriginEnvironment? DetectEnvironment()
     {
-        var environmentType = GetEnvValue("BRAINTRUST_ENVIRONMENT_TYPE");
-        if (string.IsNullOrWhiteSpace(environmentType))
-        {
-            environmentType = ReadBraintrustEnvFileValue("BRAINTRUST_ENVIRONMENT_TYPE");
-        }
+        var environmentType = GetEnvironmentConfigValue("BRAINTRUST_ENVIRONMENT_TYPE");
         if (!string.IsNullOrWhiteSpace(environmentType))
         {
-            var name = GetEnvValue("BRAINTRUST_ENVIRONMENT_NAME");
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                name = ReadBraintrustEnvFileValue("BRAINTRUST_ENVIRONMENT_NAME");
-            }
+            var name = GetEnvironmentConfigValue("BRAINTRUST_ENVIRONMENT_NAME");
             return new SpanOriginEnvironment(environmentType.Trim(), string.IsNullOrWhiteSpace(name) ? null : name.Trim());
+        }
+        if (EnvOverrides.ContainsKey("BRAINTRUST_ENVIRONMENT_TYPE"))
+        {
+            return null;
         }
 
         foreach (var (key, name) in new[]
@@ -198,17 +194,62 @@ public sealed class BraintrustConfig : BaseConfig
             return new SpanOriginEnvironment("ci", "ci");
         }
 
+        var serverName = DetectServerEnvironmentName();
+        if (serverName != null)
+        {
+            return new SpanOriginEnvironment("server", serverName);
+        }
+
+        return DeploymentModeEnvironment(GetEnvValue("ASPNETCORE_ENVIRONMENT"))
+            ?? DeploymentModeEnvironment(GetEnvValue("DOTNET_ENVIRONMENT"));
+    }
+
+    private string? GetEnvironmentConfigValue(string key)
+    {
+        var value = GetEnvValue(key);
+        if (EnvOverrides.ContainsKey(key))
+        {
+            return value;
+        }
+        return string.IsNullOrWhiteSpace(value) ? ReadBraintrustEnvFileValue(key) : value;
+    }
+
+    private string? DetectServerEnvironmentName()
+    {
+        foreach (var (key, name) in new[] { ("VERCEL", "vercel"), ("NETLIFY", "netlify") })
+        {
+            if (!string.IsNullOrWhiteSpace(GetEnvValue(key)))
+            {
+                return name;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(GetEnvValue("ECS_CONTAINER_METADATA_URI")) ||
+            !string.IsNullOrWhiteSpace(GetEnvValue("ECS_CONTAINER_METADATA_URI_V4")))
+        {
+            return "ecs";
+        }
+
+        var awsExecutionEnv = GetEnvValue("AWS_EXECUTION_ENV");
+        if (awsExecutionEnv?.StartsWith("AWS_ECS_", StringComparison.Ordinal) == true)
+        {
+            return "ecs";
+        }
+        if (awsExecutionEnv?.StartsWith("AWS_Lambda_", StringComparison.Ordinal) == true)
+        {
+            return "aws_lambda";
+        }
+
+        if (!string.IsNullOrWhiteSpace(GetEnvValue("AWS_LAMBDA_FUNCTION_NAME")))
+        {
+            return "aws_lambda";
+        }
+
         foreach (var (key, name) in new[]
         {
-            ("VERCEL", "vercel"),
-            ("NETLIFY", "netlify"),
-            ("AWS_LAMBDA_FUNCTION_NAME", "aws_lambda"),
-            ("AWS_EXECUTION_ENV", "aws_lambda"),
             ("K_SERVICE", "cloud_run"),
             ("FUNCTION_TARGET", "gcp_functions"),
             ("KUBERNETES_SERVICE_HOST", "kubernetes"),
-            ("ECS_CONTAINER_METADATA_URI", "ecs"),
-            ("ECS_CONTAINER_METADATA_URI_V4", "ecs"),
             ("DYNO", "heroku"),
             ("FLY_APP_NAME", "fly"),
             ("RAILWAY_ENVIRONMENT", "railway"),
@@ -217,12 +258,11 @@ public sealed class BraintrustConfig : BaseConfig
         {
             if (!string.IsNullOrWhiteSpace(GetEnvValue(key)))
             {
-                return new SpanOriginEnvironment("server", name);
+                return name;
             }
         }
 
-        return DeploymentModeEnvironment(GetEnvValue("ASPNETCORE_ENVIRONMENT"))
-            ?? DeploymentModeEnvironment(GetEnvValue("DOTNET_ENVIRONMENT"));
+        return null;
     }
 
     private static SpanOriginEnvironment? DeploymentModeEnvironment(string? value)

--- a/src/Braintrust.Sdk/Config/BraintrustConfig.cs
+++ b/src/Braintrust.Sdk/Config/BraintrustConfig.cs
@@ -1,5 +1,7 @@
 namespace Braintrust.Sdk.Config;
 
+public sealed record SpanOriginEnvironment(string Type, string? Name = null);
+
 /// <summary>
 /// Configuration for Braintrust SDK with sane defaults.
 ///
@@ -25,6 +27,7 @@ public sealed class BraintrustConfig : BaseConfig
     public bool EnableTraceConsoleLog { get; }
     public bool Debug { get; }
     public TimeSpan RequestTimeout { get; }
+    public SpanOriginEnvironment? Environment { get; }
 
     public static BraintrustConfig FromEnvironment()
     {
@@ -69,6 +72,7 @@ public sealed class BraintrustConfig : BaseConfig
         EnableTraceConsoleLog = GetConfig("BRAINTRUST_ENABLE_TRACE_CONSOLE_LOG", false);
         Debug = GetConfig("BRAINTRUST_DEBUG", false);
         RequestTimeout = TimeSpan.FromSeconds(GetConfig("BRAINTRUST_REQUEST_TIMEOUT", 30));
+        Environment = DetectEnvironment();
 
         if (string.IsNullOrEmpty(DefaultProjectId) && string.IsNullOrEmpty(DefaultProjectName))
         {
@@ -84,7 +88,7 @@ public sealed class BraintrustConfig : BaseConfig
             return string.IsNullOrWhiteSpace(_apiKeyOverride) ? null : _apiKeyOverride;
         }
 
-        var value = Environment.GetEnvironmentVariable(ApiKeySettingName);
+        var value = global::System.Environment.GetEnvironmentVariable(ApiKeySettingName);
         if (value == NullOverride)
         {
             return null;
@@ -101,7 +105,7 @@ public sealed class BraintrustConfig : BaseConfig
             return immediateApiKey;
         }
 
-        if (_hasApiKeyOverride || Environment.GetEnvironmentVariable(ApiKeySettingName) == NullOverride)
+        if (_hasApiKeyOverride || global::System.Environment.GetEnvironmentVariable(ApiKeySettingName) == NullOverride)
         {
             throw MissingApiKeyException();
         }
@@ -151,5 +155,130 @@ public sealed class BraintrustConfig : BaseConfig
             // should never happen
             throw new InvalidOperationException("A project name or ID is required.");
         }
+    }
+
+    private SpanOriginEnvironment? DetectEnvironment()
+    {
+        var environmentType = GetEnvValue("BRAINTRUST_ENVIRONMENT_TYPE");
+        if (string.IsNullOrWhiteSpace(environmentType))
+        {
+            environmentType = ReadBraintrustEnvFileValue("BRAINTRUST_ENVIRONMENT_TYPE");
+        }
+        if (!string.IsNullOrWhiteSpace(environmentType))
+        {
+            var name = GetEnvValue("BRAINTRUST_ENVIRONMENT_NAME");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                name = ReadBraintrustEnvFileValue("BRAINTRUST_ENVIRONMENT_NAME");
+            }
+            return new SpanOriginEnvironment(environmentType.Trim(), string.IsNullOrWhiteSpace(name) ? null : name.Trim());
+        }
+
+        foreach (var (key, name) in new[]
+        {
+            ("GITHUB_ACTIONS", "github_actions"),
+            ("GITLAB_CI", "gitlab_ci"),
+            ("CIRCLECI", "circleci"),
+            ("BUILDKITE", "buildkite"),
+            ("JENKINS_URL", "jenkins"),
+            ("JENKINS_HOME", "jenkins"),
+            ("TF_BUILD", "azure_pipelines"),
+            ("TEAMCITY_VERSION", "teamcity"),
+            ("TRAVIS", "travis"),
+            ("BITBUCKET_BUILD_NUMBER", "bitbucket")
+        })
+        {
+            if (!string.IsNullOrWhiteSpace(GetEnvValue(key)))
+            {
+                return new SpanOriginEnvironment("ci", name);
+            }
+        }
+        if (!string.IsNullOrWhiteSpace(GetEnvValue("CI")))
+        {
+            return new SpanOriginEnvironment("ci", "ci");
+        }
+
+        foreach (var (key, name) in new[]
+        {
+            ("VERCEL", "vercel"),
+            ("NETLIFY", "netlify"),
+            ("AWS_LAMBDA_FUNCTION_NAME", "aws_lambda"),
+            ("AWS_EXECUTION_ENV", "aws_lambda"),
+            ("K_SERVICE", "cloud_run"),
+            ("FUNCTION_TARGET", "gcp_functions"),
+            ("KUBERNETES_SERVICE_HOST", "kubernetes"),
+            ("ECS_CONTAINER_METADATA_URI", "ecs"),
+            ("ECS_CONTAINER_METADATA_URI_V4", "ecs"),
+            ("DYNO", "heroku"),
+            ("FLY_APP_NAME", "fly"),
+            ("RAILWAY_ENVIRONMENT", "railway"),
+            ("RENDER_SERVICE_NAME", "render")
+        })
+        {
+            if (!string.IsNullOrWhiteSpace(GetEnvValue(key)))
+            {
+                return new SpanOriginEnvironment("server", name);
+            }
+        }
+
+        return DeploymentModeEnvironment(GetEnvValue("ASPNETCORE_ENVIRONMENT"))
+            ?? DeploymentModeEnvironment(GetEnvValue("DOTNET_ENVIRONMENT"));
+    }
+
+    private static SpanOriginEnvironment? DeploymentModeEnvironment(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "production" or "staging" => new SpanOriginEnvironment("server", normalized),
+            "development" or "local" => new SpanOriginEnvironment("local", normalized),
+            _ => null
+        };
+    }
+
+    private static string? ReadBraintrustEnvFileValue(string key)
+    {
+        var dir = Directory.GetCurrentDirectory();
+        for (var depth = 0; depth <= 64; depth++)
+        {
+            var path = Path.Combine(dir, ".env.braintrust");
+            if (File.Exists(path))
+            {
+                foreach (var line in File.ReadAllLines(path))
+                {
+                    var trimmed = line.Trim();
+                    if (trimmed.Length == 0 || trimmed.StartsWith("#", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    var index = trimmed.IndexOf('=');
+                    if (index <= 0)
+                    {
+                        continue;
+                    }
+
+                    if (trimmed[..index].Trim() == key)
+                    {
+                        return trimmed[(index + 1)..].Trim().Trim('"', '\'');
+                    }
+                }
+                return null;
+            }
+
+            var parent = Directory.GetParent(dir);
+            if (parent == null)
+            {
+                return null;
+            }
+            dir = parent.FullName;
+        }
+
+        return null;
     }
 }

--- a/src/Braintrust.Sdk/Trace/BraintrustSpanProcessor.cs
+++ b/src/Braintrust.Sdk/Trace/BraintrustSpanProcessor.cs
@@ -26,8 +26,6 @@ internal sealed class BraintrustSpanProcessor : BaseProcessor<Activity>
 
     public override void OnStart(Activity activity)
     {
-        AddSpanOrigin(activity);
-
         // Check if activity already has a parent attribute
         var existingParent = activity.GetTagItem(ParentAttributeKey);
         if (existingParent != null)
@@ -144,6 +142,7 @@ internal sealed class BraintrustSpanProcessor : BaseProcessor<Activity>
 
     public override void OnEnd(Activity activity)
     {
+        AddSpanOrigin(activity);
         if (_config.Debug)
         {
             LogActivityDetails(activity);

--- a/src/Braintrust.Sdk/Trace/BraintrustSpanProcessor.cs
+++ b/src/Braintrust.Sdk/Trace/BraintrustSpanProcessor.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Text.Json;
+using Braintrust.Sdk;
 using Braintrust.Sdk.Config;
 using OpenTelemetry;
 
@@ -11,6 +13,9 @@ namespace Braintrust.Sdk.Trace;
 internal sealed class BraintrustSpanProcessor : BaseProcessor<Activity>
 {
     public const string ParentAttributeKey = "braintrust.parent";
+    private const string ContextJsonAttributeKey = "braintrust.context_json";
+    private const string EnvironmentTypeAttributeKey = "braintrust.environment.type";
+    private const string EnvironmentNameAttributeKey = "braintrust.environment.name";
 
     private readonly BraintrustConfig _config;
 
@@ -21,6 +26,8 @@ internal sealed class BraintrustSpanProcessor : BaseProcessor<Activity>
 
     public override void OnStart(Activity activity)
     {
+        AddSpanOrigin(activity);
+
         // Check if activity already has a parent attribute
         var existingParent = activity.GetTagItem(ParentAttributeKey);
         if (existingParent != null)
@@ -54,6 +61,85 @@ internal sealed class BraintrustSpanProcessor : BaseProcessor<Activity>
                 Console.WriteLine($"[BraintrustSpanProcessor] OnStart: set parent {configParent} from config for span {activity.DisplayName}");
             }
         }
+    }
+
+    private void AddSpanOrigin(Activity activity)
+    {
+        activity.SetTag(ContextJsonAttributeKey, BuildContextJson(activity.GetTagItem(ContextJsonAttributeKey) as string));
+        if (_config.Environment != null)
+        {
+            activity.SetTag(EnvironmentTypeAttributeKey, _config.Environment.Type);
+            if (!string.IsNullOrEmpty(_config.Environment.Name))
+            {
+                activity.SetTag(EnvironmentNameAttributeKey, _config.Environment.Name);
+            }
+        }
+    }
+
+    private string BuildContextJson(string? existingContextJson)
+    {
+        var context = ParseContextJson(existingContextJson);
+        if (!context.TryGetValue("span_origin", out var spanOriginValue) ||
+            spanOriginValue is not IDictionary<string, object?> spanOrigin)
+        {
+            spanOrigin = new Dictionary<string, object?>();
+            context["span_origin"] = spanOrigin;
+        }
+
+        spanOrigin.TryAdd("name", "braintrust.sdk.dotnet");
+        spanOrigin.TryAdd("version", SdkVersion.Version);
+        spanOrigin.TryAdd("instrumentation", new Dictionary<string, object?>
+        {
+            ["name"] = "braintrust-dotnet"
+        });
+        if (_config.Environment != null && !spanOrigin.ContainsKey("environment"))
+        {
+            var environment = new Dictionary<string, object?>
+            {
+                ["type"] = _config.Environment.Type
+            };
+            if (!string.IsNullOrEmpty(_config.Environment.Name))
+            {
+                environment["name"] = _config.Environment.Name;
+            }
+            spanOrigin["environment"] = environment;
+        }
+
+        return JsonSerializer.Serialize(context);
+    }
+
+    private static Dictionary<string, object?> ParseContextJson(string? existingContextJson)
+    {
+        if (string.IsNullOrWhiteSpace(existingContextJson))
+        {
+            return new Dictionary<string, object?>();
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(existingContextJson);
+            return JsonElementToObject(doc.RootElement) as Dictionary<string, object?>
+                ?? new Dictionary<string, object?>();
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, object?>();
+        }
+    }
+
+    private static object? JsonElementToObject(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => element.EnumerateObject()
+                .ToDictionary(property => property.Name, property => JsonElementToObject(property.Value)),
+            JsonValueKind.Array => element.EnumerateArray().Select(JsonElementToObject).ToList(),
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.TryGetInt64(out var longValue) ? longValue : element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null
+        };
     }
 
     public override void OnEnd(Activity activity)

--- a/src/Braintrust.Sdk/Trace/BraintrustSpanProcessor.cs
+++ b/src/Braintrust.Sdk/Trace/BraintrustSpanProcessor.cs
@@ -14,8 +14,6 @@ internal sealed class BraintrustSpanProcessor : BaseProcessor<Activity>
 {
     public const string ParentAttributeKey = "braintrust.parent";
     private const string ContextJsonAttributeKey = "braintrust.context_json";
-    private const string EnvironmentTypeAttributeKey = "braintrust.environment.type";
-    private const string EnvironmentNameAttributeKey = "braintrust.environment.name";
 
     private readonly BraintrustConfig _config;
 
@@ -64,14 +62,6 @@ internal sealed class BraintrustSpanProcessor : BaseProcessor<Activity>
     private void AddSpanOrigin(Activity activity)
     {
         activity.SetTag(ContextJsonAttributeKey, BuildContextJson(activity.GetTagItem(ContextJsonAttributeKey) as string));
-        if (_config.Environment != null)
-        {
-            activity.SetTag(EnvironmentTypeAttributeKey, _config.Environment.Type);
-            if (!string.IsNullOrEmpty(_config.Environment.Name))
-            {
-                activity.SetTag(EnvironmentNameAttributeKey, _config.Environment.Name);
-            }
-        }
     }
 
     private string BuildContextJson(string? existingContextJson)

--- a/src/Braintrust.Sdk/Trace/BraintrustTracing.cs
+++ b/src/Braintrust.Sdk/Trace/BraintrustTracing.cs
@@ -75,7 +75,8 @@ public static class BraintrustTracing
 
         tracerProviderBuilder
             .SetResourceBuilder(ResourceBuilder.CreateDefault()
-                .AddService(serviceName: OtelServiceName, serviceVersion: InstrumentationVersion))
+                .AddService(serviceName: OtelServiceName, serviceVersion: InstrumentationVersion)
+                .AddAttributes(SpanOriginEnvironmentAttributes(config)))
             .AddSource(InstrumentationName)
             .AddProcessor(spanProcessor)
             .AddOtlpExporter(otlpOptions =>
@@ -110,4 +111,21 @@ public static class BraintrustTracing
         return _activitySource.Value;
     }
 
+    private static IEnumerable<KeyValuePair<string, object>> SpanOriginEnvironmentAttributes(BraintrustConfig config)
+    {
+        if (config.Environment == null)
+        {
+            return Array.Empty<KeyValuePair<string, object>>();
+        }
+
+        var attributes = new List<KeyValuePair<string, object>>
+        {
+            new("braintrust.environment.type", config.Environment.Type)
+        };
+        if (!string.IsNullOrEmpty(config.Environment.Name))
+        {
+            attributes.Add(new KeyValuePair<string, object>("braintrust.environment.name", config.Environment.Name));
+        }
+        return attributes;
+    }
 }

--- a/src/Braintrust.Sdk/Trace/BraintrustTracing.cs
+++ b/src/Braintrust.Sdk/Trace/BraintrustTracing.cs
@@ -75,8 +75,7 @@ public static class BraintrustTracing
 
         tracerProviderBuilder
             .SetResourceBuilder(ResourceBuilder.CreateDefault()
-                .AddService(serviceName: OtelServiceName, serviceVersion: InstrumentationVersion)
-                .AddAttributes(SpanOriginEnvironmentAttributes(config)))
+                .AddService(serviceName: OtelServiceName, serviceVersion: InstrumentationVersion))
             .AddSource(InstrumentationName)
             .AddProcessor(spanProcessor)
             .AddOtlpExporter(otlpOptions =>
@@ -111,21 +110,4 @@ public static class BraintrustTracing
         return _activitySource.Value;
     }
 
-    private static IEnumerable<KeyValuePair<string, object>> SpanOriginEnvironmentAttributes(BraintrustConfig config)
-    {
-        if (config.Environment == null)
-        {
-            return Array.Empty<KeyValuePair<string, object>>();
-        }
-
-        var attributes = new List<KeyValuePair<string, object>>
-        {
-            new("braintrust.environment.type", config.Environment.Type)
-        };
-        if (!string.IsNullOrEmpty(config.Environment.Name))
-        {
-            attributes.Add(new KeyValuePair<string, object>("braintrust.environment.name", config.Environment.Name));
-        }
-        return attributes;
-    }
 }

--- a/tests/Braintrust.Sdk.Tests/Config/BraintrustConfigTest.cs
+++ b/tests/Braintrust.Sdk.Tests/Config/BraintrustConfigTest.cs
@@ -158,4 +158,54 @@ public class BraintrustConfigTest
         Assert.True(config.Debug);
         Assert.True(config.EnableTraceConsoleLog);
     }
+
+    [Fact]
+    public void ExplicitNullEnvironmentOverrideDisablesDetection()
+    {
+        var config = BraintrustConfig.Of(
+            ("BRAINTRUST_API_KEY", "test-key"),
+            ("BRAINTRUST_ENVIRONMENT_TYPE", null),
+            ("BRAINTRUST_ENVIRONMENT_NAME", null),
+            ("CI", "true"),
+            ("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE")
+        );
+
+        Assert.Null(config.Environment);
+    }
+
+    [Fact]
+    public void AwsExecutionEnvClassifiesEcsBeforeLambda()
+    {
+        var config = BraintrustConfig.Of(
+            ("BRAINTRUST_API_KEY", "test-key"),
+            ("GITHUB_ACTIONS", BaseConfig.NullOverride),
+            ("GITLAB_CI", BaseConfig.NullOverride),
+            ("CIRCLECI", BaseConfig.NullOverride),
+            ("BUILDKITE", BaseConfig.NullOverride),
+            ("CI", BaseConfig.NullOverride),
+            ("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE")
+        );
+
+        Assert.NotNull(config.Environment);
+        Assert.Equal("server", config.Environment.Type);
+        Assert.Equal("ecs", config.Environment.Name);
+    }
+
+    [Fact]
+    public void AwsExecutionEnvClassifiesLambdaWhenLambdaSpecific()
+    {
+        var config = BraintrustConfig.Of(
+            ("BRAINTRUST_API_KEY", "test-key"),
+            ("GITHUB_ACTIONS", BaseConfig.NullOverride),
+            ("GITLAB_CI", BaseConfig.NullOverride),
+            ("CIRCLECI", BaseConfig.NullOverride),
+            ("BUILDKITE", BaseConfig.NullOverride),
+            ("CI", BaseConfig.NullOverride),
+            ("AWS_EXECUTION_ENV", "AWS_Lambda_dotnet8")
+        );
+
+        Assert.NotNull(config.Environment);
+        Assert.Equal("server", config.Environment.Type);
+        Assert.Equal("aws_lambda", config.Environment.Name);
+    }
 }

--- a/tests/Braintrust.Sdk.Tests/Trace/BraintrustSpanProcessorTest.cs
+++ b/tests/Braintrust.Sdk.Tests/Trace/BraintrustSpanProcessorTest.cs
@@ -156,6 +156,8 @@ public class BraintrustSpanProcessorTest : IDisposable
             Assert.Equal(
                 "braintrust.sdk.dotnet",
                 document.RootElement.GetProperty("span_origin").GetProperty("name").GetString());
+            Assert.Null(activity.GetTagItem("braintrust.environment.type"));
+            Assert.Null(activity.GetTagItem("braintrust.environment.name"));
         }
     }
 }

--- a/tests/Braintrust.Sdk.Tests/Trace/BraintrustSpanProcessorTest.cs
+++ b/tests/Braintrust.Sdk.Tests/Trace/BraintrustSpanProcessorTest.cs
@@ -129,4 +129,33 @@ public class BraintrustSpanProcessorTest : IDisposable
             Assert.Equal("project_id:existing", parent);
         }
     }
+
+    [Fact]
+    public void OnEnd_MergesSpanOriginWithContextJsonSetAfterStart()
+    {
+        var config = BraintrustConfig.Of(
+            ("BRAINTRUST_API_KEY", "test-key"),
+            ("BRAINTRUST_DEFAULT_PROJECT_ID", "proj-config")
+        );
+        var processor = new BraintrustSpanProcessor(config);
+
+        using (var activity = _activitySource.StartActivity("test-span"))
+        {
+            Assert.NotNull(activity);
+            processor.OnStart(activity);
+            activity.SetTag("braintrust.context_json", "{\"metadata\":{\"source\":\"late-attribute\"}}");
+
+            processor.OnEnd(activity);
+
+            var contextJson = activity.GetTagItem("braintrust.context_json") as string;
+            Assert.NotNull(contextJson);
+            using var document = System.Text.Json.JsonDocument.Parse(contextJson);
+            Assert.Equal(
+                "late-attribute",
+                document.RootElement.GetProperty("metadata").GetProperty("source").GetString());
+            Assert.Equal(
+                "braintrust.sdk.dotnet",
+                document.RootElement.GetProperty("span_origin").GetProperty("name").GetString());
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds span origin provenance environment detection and OpenTelemetry context propagation to the .NET SDK.

## Validation

- DOTNET_ROOT=/opt/homebrew/opt/dotnet@8/libexec PATH=/opt/homebrew/opt/dotnet@8/bin:/Users/stephenbelanger/.nvm/versions/node/v26.3.1/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/Caskroom/codex/0.144.1/codex-path:/Users/stephenbelanger/.codex/tmp/arg0/codex-arg0hCuz7e:/Users/stephenbelanger/.rbenv/shims:/Users/stephenbelanger/.g/bin:/Users/stephenbelanger/.g/go/bin:/Users/stephenbelanger/go/bin:/Users/stephenbelanger/.nvm/versions/node/v26.3.1/bin:/Users/stephenbelanger/.local/bin:/Users/stephenbelanger/.swiftly/bin:/Users/stephenbelanger/.cargo/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/stephenbelanger/.lmstudio/bin dotnet test
- aggregate git diff --check